### PR TITLE
feat: Add FromInput component for staff evaluation slots search

### DIFF
--- a/app/app/(staff)/staff/evaluation-slots/_components/from-input/index.tsx
+++ b/app/app/(staff)/staff/evaluation-slots/_components/from-input/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Form } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface IFromInput {
+  from: string;
+}
+
+export const FromInput = (p: IFromInput) => {
+  const [value, setValue] = useState(p.from);
+  const router = useRouter();
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    console.log(value);
+    const url = `/staff/evaluation-slots?from=${value}`;
+    console.log(url);
+    router.push(url);
+  }
+  return (
+    <form className="flex gap-2 max-w-64">
+      <Button onClick={(e) => handleSubmit(e)}>Search from</Button>
+      <Input
+        type="date"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </form>
+  );
+};

--- a/app/app/(staff)/staff/evaluation-slots/page.tsx
+++ b/app/app/(staff)/staff/evaluation-slots/page.tsx
@@ -10,14 +10,28 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getEvaluatedSlots, transformEvaluationSlots } from "./utils";
+import { redirect } from "next/navigation";
+import { FromInput } from "./_components/from-input";
 
-export default async function Page() {
-  const dbEvaluationSlots = await getEvaluatedSlots();
+export default async function Page({
+  searchParams: searchParams,
+}: {
+  searchParams: { from?: string };
+}) {
+  if (!searchParams.from) {
+    const prev30Days = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const from = prev30Days.toISOString().split("T")[0];
+    redirect(`/staff/evaluation-slots?from=${from}`);
+  }
+  const dbEvaluationSlots = await getEvaluatedSlots({
+    from: searchParams.from,
+  });
   const evaluationSlots = transformEvaluationSlots(dbEvaluationSlots);
 
   return (
     <div className="flex flex-col gap-4">
       <BackBtn />
+      <FromInput from={searchParams.from} />
       <Card>
         <CardHeader>
           <CardTitle>Evaluated Slots</CardTitle>

--- a/app/app/(staff)/staff/evaluation-slots/utils.ts
+++ b/app/app/(staff)/staff/evaluation-slots/utils.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db/clients";
 import { evaluationSlots } from "@/drizzle/schemas";
-import { and, desc, isNotNull } from "drizzle-orm";
+import { and, desc, gte, isNotNull } from "drizzle-orm";
 
 type DbEvaluationSlot = {
   id: string;
@@ -16,11 +16,16 @@ type EvaluationSlot = {
   status: string;
 };
 
-export async function getEvaluatedSlots(): Promise<DbEvaluationSlot[]> {
+export async function getEvaluatedSlots({
+  from,
+}: {
+  from: string;
+}): Promise<DbEvaluationSlot[]> {
   return await db.query.evaluationSlots.findMany({
     where: and(
       isNotNull(evaluationSlots.isEvaluated),
-      evaluationSlots.isEvaluated
+      evaluationSlots.isEvaluated,
+      gte(evaluationSlots.startDateTime, new Date(from))
     ),
     columns: {
       id: true,


### PR DESCRIPTION
- Added a new component called FromInput in the staff evaluation slots feature.
- The FromInput component is responsible for rendering a form with a date input and a search button.
- When the search button is clicked, the component retrieves the selected date value and constructs a URL with the "from" query parameter.
- The component then uses the Next.js router to navigate to the evaluation slots page with the constructed URL.

Co-authored-by: [Author Name]